### PR TITLE
Use smart pointers where they make sense

### DIFF
--- a/include/animators.h
+++ b/include/animators.h
@@ -10,6 +10,7 @@ struct animator {
     virtual void update(const int frame) = 0;
 
     animator(int start, int end) : start_frame(start), end_frame(end) {}
+    virtual ~animator() {}
 };
 
 struct vec_animator : animator {

--- a/include/animators.h
+++ b/include/animators.h
@@ -19,9 +19,9 @@ struct vec_animator : animator {
 
     void update(const int frame) override;
 
-    vec_animator(int start, int end, vec *a, vec startvec, vec endvec) :
-        animator(start, end), vec_ptr(a), start_vec(startvec),
-        end_vec(endvec) {}
+    vec_animator(int start, int end, vec *a, vec startvec, vec endvec)
+        : animator(start, end), vec_ptr(a),
+          start_vec(startvec), end_vec(endvec) {}
 };
 
 #endif //ANIMATIONS_H

--- a/include/camera.h
+++ b/include/camera.h
@@ -5,6 +5,7 @@
 #include <string>
 
 #include <cairo.h>
+
 #include "vec.h"
 
 struct scene;

--- a/include/camera.h
+++ b/include/camera.h
@@ -1,7 +1,9 @@
 #ifndef CAMERA_H
 #define CAMERA_H
 
+#include <memory>
 #include <string>
+
 #include <cairo.h>
 #include "vec.h"
 
@@ -10,34 +12,22 @@ struct scene;
 struct camera {
     vec location, size;
     std::string url_base;
-    cairo_surface_t *image, *scene_surface;
-    cairo_t *camera_ctx, *scene_ctx;
+
+    std::unique_ptr<cairo_surface_t, decltype(&cairo_surface_destroy)> image;
+    std::unique_ptr<cairo_t, decltype(&cairo_destroy)> context;
 
     void clear_camera();
-    void clear_scene(scene &s);
 
     void move_by(vec displace);
     void move_to(vec position);
 
     void capture(scene &s);
-
     void write_to_png(scene &s, const char *url);
 
-    void destroy();
-
-    camera() : location({0, 0}), size({600, 400}), url_base("/tmp/img") {}
-
-    camera(std::string url) : location({0, 0}), size({600, 400}),
-        url_base(url) {}
-
-    camera(vec camera_size, std::string url) : location({0, 0}),
-        size(camera_size), url_base(url) {}
-
-    camera(vec loc, vec camera_size, std::string url) : location(-1 * location),
-        size(camera_size), url_base(url) {}
-
-private:
-    void create_surfaces(scene &s);
+    camera() : camera("/tmp/img") {}
+    camera(std::string url) : camera({600, 400}, url) {}
+    camera(vec camera_size, std::string url) : camera({0, 0}, camera_size, url) {}
+    camera(vec loc, vec camera_size, std::string url);
 };
 
 #endif //CAMERA_H

--- a/include/layer.h
+++ b/include/layer.h
@@ -1,19 +1,20 @@
 #ifndef LAYER_H
 #define LAYER_H
 
-#include <cairo.h>
+#include <memory>
 #include <vector>
+
+#include <cairo.h>
+
 #include "vec.h"
 #include "color.h"
 #include "shapes.h"
 
 struct layer {
-    std::vector<shape*> shapes;
+    std::vector<std::shared_ptr<shape>> shapes;
 
     void draw(cairo_t *ctx);
     void update(int frame);
-
-    void clear();
 };
 
 #endif //LAYER_h

--- a/include/layer.h
+++ b/include/layer.h
@@ -13,7 +13,7 @@
 struct layer {
     std::vector<std::shared_ptr<shape>> shapes;
 
-    void draw(cairo_t *ctx);
+    void draw(cairo_t *ctx) const;
     void update(int frame);
 };
 

--- a/include/scene.h
+++ b/include/scene.h
@@ -1,8 +1,11 @@
 #ifndef SCENE_H
 #define SCENE_H
 
+#include <memory>
 #include <vector>
+
 #include <cairo.h>
+
 #include "vec.h"
 #include "color.h"
 #include "layer.h"
@@ -15,39 +18,23 @@ struct scene {
     color bg_clr;
     std::vector<layer> layers;
 
-    void draw(cairo_t *ctx);
-    void update(const int frame);
+    std::unique_ptr<cairo_surface_t, decltype(&cairo_surface_destroy)> surface;
+    std::unique_ptr<cairo_t, decltype(&cairo_destroy)> context;
 
-    int add_shape(shape *shp, int layer_pos);
-    int add_animator(animator *anim, int layer_pos, int shape_pos);
+    void draw();
+    void update(int frame);
+
+    void add_shape(std::shared_ptr<shape> shp, int layer_pos);
 
     void add_layer();
     void add_layers(int num_layers);
     void add_layer_at(int position);
     void add_layers_from(int position, int num_layers);
 
-    void clear_layer(int layer_num);
-    void clear();
-
-    scene() : size({600, 400}), bg_clr({0.0, 0.0, 0.0, 1.0}) {
-        layers.emplace_back(layer());
-    }
-
-    scene(color bg_color) : size({600, 400}), bg_clr(bg_color) {
-        layers.emplace_back(layer());
-    }
-
-    scene(vec scene_size) : size(scene_size), bg_clr({0.0, 0.0, 0.0, 1.0}) {
-        layers.emplace_back(layer());
-    }
-
-    scene(vec scene_size, color bg_color) : size(scene_size), bg_clr(bg_color) {
-        layers.emplace_back(layer());
-    }
-
-    ~scene() {
-        clear();
-    }
+    scene() : scene({600, 400}, {0.0, 0.0, 0.0, 1.0}) { }
+    scene(color bg_color) : scene({600, 400}, bg_color) { }
+    scene(vec scene_size) : scene(scene_size, {0.0, 0.0, 0.0, 1.0}) {}
+    scene(vec scene_size, color bg_color);
 };
 
 #endif //SCENE_H

--- a/include/shapes.h
+++ b/include/shapes.h
@@ -1,23 +1,31 @@
 #ifndef SHAPES_H
 #define SHAPES_H
 
-#include <vector>
 #include <cmath>
+#include <memory>
+#include <vector>
+
 #include <cairo.h>
+
 #include "vec.h"
 #include "color.h"
 #include "animators.h"
 
 struct shape {
     color clr;
-    std::vector<animator*> animators;
+    std::vector<std::unique_ptr<animator>> animators;
 
-    virtual void draw(cairo_t *) = 0;
+    template <typename A, typename... Args>
+    void add_animator(Args&&... args) {
+      animators.emplace_back(std::make_unique<A>(std::forward<Args>(args)...));
+    }
+
+    virtual void draw(cairo_t *) const = 0;
     void update(const int frame);
-    void clear_animators();
 
-    shape() : clr({1.0, 1.0, 1.0, 1.0}) {}
+    shape() : shape({1.0, 1.0, 1.0, 1.0}) {}
     shape(color shape_clr) : clr(shape_clr) {}
+    virtual ~shape() {}
 };
 
 struct ellipse : shape {
@@ -27,15 +35,15 @@ struct ellipse : shape {
     double rotation;
     bool fill;
 
-    void draw(cairo_t *) override;
+    void draw(cairo_t *) const override;
 
     ellipse(vec loc, vec sz, double rotate, bool elp_fill) :
-        location(loc), size(sz), rotation(rotate), fill(elp_fill),
-        angles({0.0, 2.0 * M_PI}) {}
+        location(loc), size(sz), angles({0.0, 2.0 * M_PI}),
+        rotation(rotate), fill(elp_fill) {}
 
     ellipse(color elp_clr, vec loc, vec sz, double rotate, bool elp_fill) :
-        shape(elp_clr), location(loc), size(sz), rotation(rotate),
-        fill(elp_fill), angles({0.0, 2.0 * M_PI}) {}
+        shape(elp_clr), location(loc), size(sz), angles({0.0, 2.0 * M_PI}),
+        rotation(rotate), fill(elp_fill) {}
 };
 
 struct arc : shape {
@@ -43,7 +51,7 @@ struct arc : shape {
     vec size;
     vec angles;
 
-    void draw(cairo_t *) override;
+    void draw(cairo_t *) const override;
 
     arc(vec loc, vec sz, vec arc_angles) :  location(loc), size(sz),
         angles(arc_angles) {}
@@ -56,7 +64,7 @@ struct line : shape {
     vec start;
     vec end;
 
-    void draw(cairo_t *) override;
+    void draw(cairo_t *) const override;
 
     line(vec line_start, vec line_end) : start(line_start), end(line_end) {}
 
@@ -70,7 +78,7 @@ struct rectangle : shape {
     double rotation;
     bool fill;
 
-    void draw(cairo_t *) override;
+    void draw(cairo_t *) const override;
 
     rectangle(vec loc, vec sz, double rotate, bool rec_fill) : location(loc),
         size(sz), rotation(rotate), fill(rec_fill) {}

--- a/src/animators.cpp
+++ b/src/animators.cpp
@@ -3,7 +3,7 @@
 void vec_animator::update(const int frame) {
     if (vec_ptr && frame > start_frame && frame < end_frame) {
         *vec_ptr = start_vec + (end_vec - start_vec) * (frame - start_frame) /
-                    (end_frame - start_frame);
+                   (end_frame - start_frame);
     } else if (vec_ptr && frame >= end_frame) {
         *vec_ptr = end_vec;
     }

--- a/src/camera.cpp
+++ b/src/camera.cpp
@@ -2,9 +2,9 @@
 #include "../include/scene.h"
 
 void camera::clear_camera() {
-        cairo_set_source_rgba(context.get(), 0, 0, 0, 0);
-        cairo_set_operator(context.get(), CAIRO_OPERATOR_SOURCE);
-        cairo_paint(context.get());
+    cairo_set_source_rgba(context.get(), 0, 0, 0, 0);
+    cairo_set_operator(context.get(), CAIRO_OPERATOR_SOURCE);
+    cairo_paint(context.get());
 }
 
 void camera::move_by(vec displace) {
@@ -29,8 +29,7 @@ void camera::write_to_png(scene &s, const char *url) {
 }
 
 camera::camera(vec loc, vec camera_size, std::string url)
-  : location(-1 * loc), size(camera_size), url_base(url),
-    image(cairo_image_surface_create(CAIRO_FORMAT_ARGB32, static_cast<int>(size.x), static_cast<int>(size.y)), cairo_surface_destroy),
-    context(cairo_create(image.get()), cairo_destroy) {
-}
+    : location(-1 * loc), size(camera_size), url_base(url),
+      image(cairo_image_surface_create(CAIRO_FORMAT_ARGB32, static_cast<int>(size.x), static_cast<int>(size.y)), cairo_surface_destroy),
+      context(cairo_create(image.get()), cairo_destroy) {}
 

--- a/src/camera.cpp
+++ b/src/camera.cpp
@@ -1,35 +1,10 @@
 #include "../include/camera.h"
 #include "../include/scene.h"
 
-void camera::create_surfaces(scene &s) {
-    image = cairo_image_surface_create(CAIRO_FORMAT_ARGB32, size.x, size.y);
-    camera_ctx = cairo_create(image);
-
-    scene_surface = cairo_image_surface_create(CAIRO_FORMAT_ARGB32, s.size.x,
-                                                s.size.y);
-    scene_ctx = cairo_create(scene_surface);
-    cairo_set_line_width(scene_ctx, 3);
-    cairo_set_font_size(scene_ctx, 50.0);
-    cairo_set_line_join(scene_ctx, CAIRO_LINE_JOIN_BEVEL);
-    cairo_set_line_cap(scene_ctx, CAIRO_LINE_CAP_ROUND);
-
-    cairo_set_source_rgba(scene_ctx, s.bg_clr.r, s.bg_clr.g, s.bg_clr.b,
-                            s.bg_clr.a);
-    cairo_rectangle(scene_ctx, 0, 0, s.size.x, s.size.y);
-    cairo_fill(scene_ctx);
-}
-
 void camera::clear_camera() {
-        cairo_set_source_rgba(camera_ctx, 0, 0, 0, 0);
-        cairo_set_operator(camera_ctx, CAIRO_OPERATOR_SOURCE);
-        cairo_paint(camera_ctx);
-}
-
-void camera::clear_scene(scene &s) {
-    cairo_set_source_rgba(scene_ctx, s.bg_clr.r, s.bg_clr.g, s.bg_clr.b,
-                            s.bg_clr.a);
-    cairo_set_operator(scene_ctx, CAIRO_OPERATOR_SOURCE);
-    cairo_paint(scene_ctx);
+        cairo_set_source_rgba(context.get(), 0, 0, 0, 0);
+        cairo_set_operator(context.get(), CAIRO_OPERATOR_SOURCE);
+        cairo_paint(context.get());
 }
 
 void camera::move_by(vec displace) {
@@ -41,22 +16,21 @@ void camera::move_to(vec position) {
 }
 
 void camera::capture(scene &s) {
-    create_surfaces(s);
-    s.draw(scene_ctx);
-    cairo_set_source_surface(camera_ctx, scene_surface, (int)location.x,
-                                (int)location.y);
-    cairo_paint(camera_ctx);
+    s.draw();
+    cairo_set_source_surface(context.get(), s.surface.get(),
+                             static_cast<int>(location.x),
+                             static_cast<int>(location.y));
+    cairo_paint(context.get());
 }
 
 void camera::write_to_png(scene &s, const char *url) {
     capture(s);
-    cairo_surface_write_to_png(image, url);
-    destroy();
+    cairo_surface_write_to_png(image.get(), url);
 }
 
-void camera::destroy() {
-    cairo_destroy(camera_ctx);
-    cairo_destroy(scene_ctx);
-    cairo_surface_destroy(image);
-    cairo_surface_destroy(scene_surface);
+camera::camera(vec loc, vec camera_size, std::string url)
+  : location(-1 * loc), size(camera_size), url_base(url),
+    image(cairo_image_surface_create(CAIRO_FORMAT_ARGB32, static_cast<int>(size.x), static_cast<int>(size.y)), cairo_surface_destroy),
+    context(cairo_create(image.get()), cairo_destroy) {
 }
+

--- a/src/layer.cpp
+++ b/src/layer.cpp
@@ -1,13 +1,13 @@
 #include "../include/layer.h"
 
-void layer::draw(cairo_t *ctx) {
-    for (auto shp : shapes) {
+void layer::draw(cairo_t *ctx) const {
+    for (const auto& shp : shapes) {
         shp->draw(ctx);
     }
 }
 
 void layer::update(int frame) {
-    for (auto shp : shapes) {
+    for (auto& shp : shapes) {
         shp->update(frame);
     }
 }

--- a/src/layer.cpp
+++ b/src/layer.cpp
@@ -11,12 +11,3 @@ void layer::update(int frame) {
         shp->update(frame);
     }
 }
-
-void layer::clear() {
-    while (shapes.size() > 0) {
-        auto shp = shapes.back();
-        shapes.pop_back();
-        shp->clear_animators();
-        delete shp;
-    }
-}

--- a/src/scene.cpp
+++ b/src/scene.cpp
@@ -1,9 +1,25 @@
 #include "../include/scene.h"
 #include <iterator>
 
-void scene::draw(cairo_t *ctx) {
+scene::scene(vec scene_size, color bg_color)
+ : size(scene_size), bg_clr(bg_color),
+   surface(cairo_image_surface_create(CAIRO_FORMAT_ARGB32, static_cast<int>(size.x), static_cast<int>(size.y)), cairo_surface_destroy),
+   context(cairo_create(surface.get()), cairo_destroy) {
+    layers.emplace_back();
+
+    cairo_set_line_width(context.get(), 3);
+    cairo_set_font_size(context.get(), 50.0);
+    cairo_set_line_join(context.get(), CAIRO_LINE_JOIN_BEVEL);
+    cairo_set_line_cap(context.get(), CAIRO_LINE_CAP_ROUND);
+}
+
+void scene::draw() {
+    cairo_set_source_rgba(context.get(), bg_clr.r, bg_clr.g, bg_clr.b, bg_clr.a);
+    cairo_set_operator(context.get(), CAIRO_OPERATOR_SOURCE);
+    cairo_paint(context.get());
+
     for (auto l : layers) {
-        l.draw(ctx);
+        l.draw(context.get());
     }
 }
 
@@ -13,18 +29,12 @@ void scene::update(const int frame) {
     }
 }
 
-int scene::add_shape(shape *shp, int layer_pos) {
+void scene::add_shape(std::shared_ptr<shape> shp, int layer_pos) {
     layers[layer_pos].shapes.push_back(shp);
-    return layers[layer_pos].shapes.size() - 1;
-}
-
-int scene::add_animator(animator *anim, int layer_pos, int shape_pos) {
-    layers[layer_pos].shapes[shape_pos]->animators.push_back(anim);
-    return layers[layer_pos].shapes[shape_pos]->animators.size() - 1;
 }
 
 void scene::add_layer() {
-    layers.push_back(layer());
+    layers.emplace_back();
 }
 
 void scene::add_layers(int num_layers) {
@@ -41,12 +51,4 @@ void scene::add_layers_from(int position, int num_layers) {
     auto iter = layers.begin();
     std::advance(iter, position);
     layers.insert(iter, num_layers, layer());
-}
-
-void scene::clear_layer(int layer_num) {
-    layers[layer_num].clear();
-}
-
-void scene::clear() {
-    layers.clear();
 }

--- a/src/scene.cpp
+++ b/src/scene.cpp
@@ -2,11 +2,11 @@
 #include <iterator>
 
 scene::scene(vec scene_size, color bg_color)
- : size(scene_size), bg_clr(bg_color),
-   surface(cairo_image_surface_create(CAIRO_FORMAT_ARGB32, static_cast<int>(size.x), static_cast<int>(size.y)), cairo_surface_destroy),
-   context(cairo_create(surface.get()), cairo_destroy) {
-    layers.emplace_back();
+    : size(scene_size), bg_clr(bg_color),
+      surface(cairo_image_surface_create(CAIRO_FORMAT_ARGB32, static_cast<int>(size.x), static_cast<int>(size.y)), cairo_surface_destroy),
+      context(cairo_create(surface.get()), cairo_destroy) {
 
+    layers.emplace_back();
     cairo_set_line_width(context.get(), 3);
     cairo_set_font_size(context.get(), 50.0);
     cairo_set_line_join(context.get(), CAIRO_LINE_JOIN_BEVEL);
@@ -18,13 +18,13 @@ void scene::draw() {
     cairo_set_operator(context.get(), CAIRO_OPERATOR_SOURCE);
     cairo_paint(context.get());
 
-    for (auto l : layers) {
+    for (const auto& l : layers) {
         l.draw(context.get());
     }
 }
 
 void scene::update(const int frame) {
-    for (auto l : layers) {
+    for (auto& l : layers) {
         l.update(frame);
     }
 }

--- a/src/shapes.cpp
+++ b/src/shapes.cpp
@@ -2,20 +2,12 @@
 #include "../include/scene.h"
 
 void shape::update(const int frame) {
-    for (auto anim : animators) {
+    for (auto& anim : animators) {
         anim->update(frame);
     }
 }
 
-void shape::clear_animators() {
-    while (animators.size() > 0) {
-        auto anim = animators.back();
-        animators.pop_back();
-        delete anim;
-    }
-}
-
-void ellipse::draw(cairo_t *ctx) {
+void ellipse::draw(cairo_t *ctx) const {
     cairo_set_source_rgba(ctx, clr.r, clr.g, clr.b, clr.a);
     cairo_rotate(ctx, rotation);
 
@@ -38,7 +30,7 @@ void ellipse::draw(cairo_t *ctx) {
     cairo_rotate(ctx, -1.0 * rotation);
 }
 
-void arc::draw(cairo_t *ctx) {
+void arc::draw(cairo_t *ctx) const {
     cairo_set_source_rgba(ctx, clr.r, clr.g, clr.b, clr.a);
 
     if (size.x < size.y) {
@@ -56,14 +48,14 @@ void arc::draw(cairo_t *ctx) {
     cairo_stroke(ctx);
 }
 
-void line::draw(cairo_t * ctx) {
+void line::draw(cairo_t * ctx) const {
     cairo_set_source_rgba(ctx, clr.r, clr.g, clr.b, clr.a);
     cairo_move_to(ctx, start.x, start.y);
     cairo_line_to(ctx, end.x, end.y);
     cairo_stroke(ctx);
 }
 
-void rectangle::draw(cairo_t *ctx) {
+void rectangle::draw(cairo_t *ctx) const {
     cairo_set_source_rgba(ctx, clr.r, clr.g, clr.b, clr.a);
     cairo_rotate(ctx, rotation);
 

--- a/src/vis_test.cpp
+++ b/src/vis_test.cpp
@@ -1,46 +1,39 @@
 #include <iostream>
 #include <sstream>
 #include <iomanip>
+#include <memory>
 #include <vector>
+
 #include "../include/camera.h"
 #include "../include/scene.h"
 #include "../include/shapes.h"
 #include "../include/color.h"
 
 int main() {
-    camera cam = camera({400, 400}, "/tmp/img");
+    camera cam({400, 400}, "/tmp/img");
     scene s = scene({400, 400}, {0, 0, 0, 1});
 
-    ellipse *root = new ellipse({1.0, 0.0, 0.0, 1.0}, {200.0, 110.0},
-                                    {0.0, 0.0}, 0.0, true);
+    auto root = std::make_shared<ellipse>(color{1.0, 0.0, 0.0, 1.0}, vec{200.0, 110.0}, vec{0.0, 0.0}, 0.0, true);
+    root->add_animator<vec_animator>(0, 49, &root->size, vec{0.0, 0.0}, vec{50.0, 50.0});
 
-    line *line_a = new line({1.0, 1.0, 1.0, 1.0}, {200.0, 110.0},
-                                {200.0, 110.0});
-    line *line_b = new line({1.0, 1.0, 1.0, 1.0}, {200.0, 110.0},
-                                {200.0, 110.0});
+    auto line_a = std::make_shared<line>(color{1.0, 1.0, 1.0, 1.0}, vec{200.0, 110.0}, vec{200.0, 110.0});
+    line_a->add_animator<vec_animator>(0, 49, &line_a->end, vec{200.0, 110.0}, vec{110.0, 210.0});
 
-    ellipse *a_node = new ellipse({1.0, 0.0, 0.0, 1.0}, {110.0, 210.0},
-                                    {0.0, 0.0}, 0.0, true);
-    ellipse *b_node = new ellipse({1.0, 0.0, 0.0, 1.0}, {310.0, 210.0},
-                                    {0.0, 0.0}, 0.0, true);
+    auto line_b = std::make_shared<line>(color{1.0, 1.0, 1.0, 1.0}, vec{200.0, 110.0}, vec{200.0, 110.0});
+    line_b->add_animator<vec_animator>(0, 49, &line_b->end, vec{200.0, 110.0}, vec{310.0, 210.0});
+
+    auto a_node = std::make_shared<ellipse>(color{1.0, 0.0, 0.0, 1.0}, vec{110.0, 210.0}, vec{0.0, 0.0}, 0.0, true);
+    a_node->add_animator<vec_animator>(0, 49, &a_node->size, vec{0.0, 0.0}, vec{50.0, 50.0});
+
+    auto b_node = std::make_shared<ellipse>(color{1.0, 0.0, 0.0, 1.0}, vec{310.0, 210.0}, vec{0.0, 0.0}, 0.0, true);
+    b_node->add_animator<vec_animator>(0, 49, &b_node->size, vec{0.0, 0.0}, vec{50.0, 50.0});
 
     s.add_layer();
-    int line_a_pos = s.add_shape(line_a, 1);
-    int line_b_pos = s.add_shape(line_b, 1);
-    int a_node_pos = s.add_shape(a_node, 0);
-    int b_node_pos = s.add_shape(b_node, 0);
-    int root_pos = s.add_shape(root, 0);
-
-    s.add_animator(new vec_animator(0, 49, &root->size, {0.0, 0.0},
-                                        {50.0, 50.0}), 0, root_pos);
-    s.add_animator(new vec_animator(0, 49, &a_node->size, {0.0, 0.0},
-                                        {50.0, 50.0}), 0, a_node_pos);
-    s.add_animator(new vec_animator(0, 49, &b_node->size, {0.0, 0.0},
-                                        {50.0, 50.0}), 0, b_node_pos);
-    s.add_animator(new vec_animator(0, 49, &line_a->end, {200.0, 110.0},
-                                        {110.0, 210.0}), 1, line_a_pos);
-    s.add_animator(new vec_animator(0, 49, &line_b->end, {200.0, 110.0},
-                                        {310.0, 210.0}), 1, line_b_pos);
+    s.add_shape(line_a, 1);
+    s.add_shape(line_b, 1);
+    s.add_shape(a_node, 0);
+    s.add_shape(b_node, 0);
+    s.add_shape(root, 0);
 
     for (int i = 0; i < 50; ++i) {
         std::string url, number;


### PR DESCRIPTION
If you don't want to allow the same shape to be added to multiple layers then `std::vector<std::unique_ptr<shape>>` would make more sense (and be more performant). The current solution is more general so it's a pretty good starting point.